### PR TITLE
Mod+Return Fix (I think)

### DIFF
--- a/src/defaults/i3.template
+++ b/src/defaults/i3.template
@@ -13,7 +13,7 @@ font xft:URWGothic-Book 11
 
 floating_modifier $mod
 
-bindsym $mod+Return exec terminal
+bindsym $mod+Return exec i3-sensible-terminal
 
 # Window kill command
 bindsym $mod+Shift+q kill


### PR DESCRIPTION
I'm not sure if this is a typo or just some weird setup issue but mod+return executes "terminal" not "i3-sensible-terminal" and I've never heard of executing a terminal that way. Close this PR if I'm missing some dependency or something where 'terminal' is an executable.