### PR TITLE
Fix invalid hex color-value in theme

### DIFF
--- a/src/themes/001.json
+++ b/src/themes/001.json
@@ -17,7 +17,7 @@
         "color11": "#B36D43",
         "color12": "#78824B",
         "color13": "#D99F57",
-        "color14": "#C9AA554",
+        "color14": "#C9A554",
         "color15": "#EAD49B",
         "rofi.color-window": "#1E272B, #9D6A47, #9D6A47",
         "rofi.color-normal": "#1E272B, #EAD49B, #1E272B, #1E272B, #78824B",


### PR DESCRIPTION
I'm not sure what value it's supposed to be but it's similar to xresources.color6.