### PR TITLE
add screen power and volume function key control

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ effort to make it meet everyone's needs/likings.
 <li><a href="https://aur.archlinux.org/packages/nerd-fonts-complete/">nerd-fonts-complete</a></li>
 <li><a href="https://github.com/adobe-fonts/source-code-pro">Adobe Source Code Pro font</a></li>
 <li><a href="https://wiki.archlinux.org/index.php/Rxvt-unicode">rxvt-unicode</a></li>
+<li><a href="https://archlinux.org/packages/extra/x86_64/alsa-utils">alsa-utils</a></li>
+<li><a href="https://archlinux.org/packages/community/x86_64/meta-power-manager">meta-power-manager</a></li>
 </ul>
 
 <h2>Using the script</h2>

--- a/src/defaults/i3.template
+++ b/src/defaults/i3.template
@@ -209,7 +209,7 @@ mode "resize" {
 # Autostart applications
 exec --no-startup-id nitrogen --restore; sleep 1; compton -b
 exec --no-startup-id nm-applet
-exec --no-startup-id xfce4-power-manager
+# exec --no-startup-id xfce4-power-manager
 exec --no-startup-id pamac-tray
 exec --no-startup-id clipit
 exec_always --no-startup-id ff-theme-util
@@ -267,3 +267,10 @@ mode "$mode_gaps_outer" {
         bindsym Return mode "default"
         bindsym Escape mode "default"
 }
+
+# set power-manager and volume control
+exec --no-startup-id mate-power-manager
+
+bindsym XF86AudioRaiseVolume exec --no-startup-id amixer -c 0 -q set Master 2dB+ unmute
+bindsym XF86AudioLowerVolume exec --no-startup-id amixer -c 0 -q set Master 2db- unmute
+bindsym XF86AudioMute exec --no-startup-id amixer -q set Master toggle


### PR DESCRIPTION
In laptop or some functional key mapping keyboard, I add this feature to support that you can use `Fn+<functional control key>` to adjust volume and screen brightness.It needs two more additional packaged installed(alsa-utils/meta-power-manager).And I'v tested it in my laptop(environment: ArchLinux).
btw,nice project, thanks a lot:)