### PR TITLE
Add yaml support for themes

### DIFF
--- a/i3wm-themer.py
+++ b/i3wm-themer.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     parser.add_argument('-c', '--config', type=str, required=True, help='Load config file')
     parser.add_argument('-b', '--backup', type=str, help='Backup files')
     parser.add_argument('-i', '--install', type=str, help='Install i3wm-themer\'s default configuration files')
-    parser.add_argument('-l', '--load', type=str, help='Load theme from JSON file')
+    parser.add_argument('-l', '--load', type=str, help='Load theme from JSON or YAML file')
     args = parser.parse_args()
 
     # TODO :: Default

--- a/i3wmthemer/utils/fileutils.py
+++ b/i3wmthemer/utils/fileutils.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import logging
 import os.path
 from os import fdopen, remove
@@ -45,11 +46,14 @@ class FileUtils:
         """
         file = ''
         if FileUtils.locate_file(path):
-            logger.warning('Located the Json file.')
-            with open(path) as json_data:
-                file = json.load(json_data)
+            logger.warning('Located the theme file.')
+            with open(path) as theme_data:
+                if file.endswith("json"):
+                    file = json.load(theme_data)
+                else:
+                    file = yaml.safe_load(theme_data)
         else:
-            logger.error('Failed to locate the Json file.')
+            logger.error('Failed to locate the theme file.')
             exit(9)
 
         return file


### PR DESCRIPTION
While this won't provide full YAML syntax support, it at least allows for users to specify the theme format using the json primitives as YAML syntax. 

I used this in my own fork to allow support for comments in the theme files, so perhaps it might be of use here as well.

Feel free to suggest any changes!