### PR TITLE
fix: format-connected-foreground not correctly replaced

### DIFF
--- a/i3wmthemer/models/polybar.py
+++ b/i3wmthemer/models/polybar.py
@@ -87,7 +87,7 @@ class PolybarTheme(AbstractTheme):
             FileUtils.replace_line(configuration.polybar_config, 'label-separator-foreground',
                                    'label-separator-foreground = ' + self.label_sep_fore)
             FileUtils.replace_line(configuration.polybar_config, 'format-connected-foreground',
-                                   'format-connected-foreground = ' + self.format_con_back)
+                                   'format-connected-foreground = ' + self.format_con_fore)
             FileUtils.replace_line(configuration.polybar_config, 'format-connected-background',
                                    'format-connected-background = ' + self.format_con_back)
             FileUtils.replace_line(configuration.polybar_config, 'format-connected-prefix-foreground',


### PR DESCRIPTION
This pull request fixes an issue where the 'format-connected-foreground' variable wasn't being replaced correctly. 
This was due to the class member `format_con_back` being referenced when `format_con_fore` should have been referenced instead.