### PR TITLE
This fixes an issue that caused system to become frozen on logout using POP_OS

### DIFF
--- a/defaults/polybar.template
+++ b/defaults/polybar.template
@@ -147,7 +147,7 @@ menu-2-1 = cancel
 menu-2-1-exec = menu-open-0
 
 menu-3-0 = log off
-menu-3-0-exec = pkill -KILL -u $USER
+menu-3-0-exec = i3 exit logout
 menu-3-1 = cancel
 menu-3-1-exec = menu-open-0
 


### PR DESCRIPTION
tested on POP_OS

Issue: pressing the logout button on polybar does no bring back to login screen. It instead brings the user to the BIOS screen and stays frozen there.

Fix: By doing this change I was able to fix the issue. Logout now sends the user back to the login screen.