### PR TITLE
Install and yaml fix

### DIFF
--- a/i3wmthemer/models/configuration.py
+++ b/i3wmthemer/models/configuration.py
@@ -83,7 +83,7 @@ class ConfigurationLoader:
         if FileUtils.locate_file(self.filepath):
             logger.warning('Located the config file')
             config_path = open(self.filepath, 'r')
-            config = yaml.load_all(config_path, Loader=yaml.FullLoader)
+            config = yaml.load_all(config_path)
 
             for conf in config:
                 for n, v in conf.items():

--- a/i3wmthemer/models/configuration.py
+++ b/i3wmthemer/models/configuration.py
@@ -83,7 +83,7 @@ class ConfigurationLoader:
         if FileUtils.locate_file(self.filepath):
             logger.warning('Located the config file')
             config_path = open(self.filepath, 'r')
-            config = yaml.load_all(config_path)
+            config = yaml.load_all(config_path, Loader=yaml.FullLoader)
 
             for conf in config:
                 for n, v in conf.items():

--- a/install_arch.sh
+++ b/install_arch.sh
@@ -10,28 +10,27 @@ sudo pacman -Syy
 
 # Added binutils,gcc,make,pkg-config,fakeroot for compilations, removed yaourt
 # Added python-yaml, removed pip install
-sudo pacman -S git nitrogen rofi python-pip ttf-font-awesome adobe-source-code-pro-fonts binutils gcc make pkg-config fakeroot python-yaml ttf-nerd-fonts-symbols --noconfirm
+sudo pacman -S git nitrogen rofi python-pip ttf-font-awesome adobe-source-code-pro-fonts binutils gcc make pkg-config fakeroot python-yaml ttf-nerd-fonts-symbols git --noconfirm
 
 # Look for and use common AUR helpers from https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers
 if [ -x "$(command -v yay)" ]; then
-  yay -S polybar-git 
+  yay -S polybar 
 elif [ -x "$(command -v trizen)" ]; then
-  trizen -S polybar-git 
+  trizen -S polybar 
 elif [ -x "$(command -v pikaur)" ]; then
-  pikaur -S polybar-git 
+  pikaur -S polybar 
 elif [ -x "$(command -v pakku)" ]; then
-  pakku -S polybar-git 
+  pakku -S polybar 
 elif [ -x "$(command -v aura)" ]; then
-  aura -SA polybar-git 
+  aura -SA polybar 
 elif [ -x "$(command -v pacaur)" ]; then
-  pacaur -S polybar-git 
+  pacaur -S polybar 
 elif [ -x "$(command -v auracle)" ]; then
-  auracle download polybar-git
-  (cd "$PWD"/polybar-git && makepkg -si --noconfirm)
+  auracle download polybar
+  (cd polybar && makepkg -si --noconfirm && cd ../.. && rm -rf polybar)
 else
-  echo "No common AUR Helpers found!"
-  echo "This script requires an AUR Helper to install the following packages: polybar-git"
-  echo "Please install an AUR helper and try again"
+  git clone https://aur.archlinux.org/polybar.git 
+  (cd polybar && makepkg -si --noconfirm && cd ../.. && rm -rf polybar)
   exit 1
 fi
 

--- a/install_arch.sh
+++ b/install_arch.sh
@@ -27,7 +27,7 @@ elif [ -x "$(command -v pacaur)" ]; then
   pacaur -S polybar-git 
 elif [ -x "$(command -v auracle)" ]; then
   auracle download polybar-git
-  (cd $PWD/polybar-git && makepkg -si --noconfirm)
+  (cd "$PWD"/polybar-git && makepkg -si --noconfirm)
 else
   echo "No common AUR Helpers found!"
   echo "This script requires an AUR Helper to install the following packages: polybar-git"

--- a/install_arch.sh
+++ b/install_arch.sh
@@ -10,27 +10,24 @@ sudo pacman -Syy
 
 # Added binutils,gcc,make,pkg-config,fakeroot for compilations, removed yaourt
 # Added python-yaml, removed pip install
-sudo pacman -S git nitrogen rofi python-pip ttf-font-awesome adobe-source-code-pro-fonts binutils gcc make pkg-config fakeroot python-yaml ttf-nerd-fonts-symbols --noconfirm
+sudo pacman -S git nitrogen rofi python-pip ttf-font-awesome adobe-source-code-pro-fonts binutils gcc make pkg-config fakeroot python-yaml --noconfirm
 
 # Look for and use common AUR helpers from https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers
 if [ -x "$(command -v yay)" ]; then
-  yay -S polybar-git 
+  yay -S polybar-git ttf-nerd-fonts-symbols
 elif [ -x "$(command -v trizen)" ]; then
-  trizen -S polybar-git 
+  trizen -S polybar-git ttf-nerd-fonts-symbols
 elif [ -x "$(command -v pikaur)" ]; then
-  pikaur -S polybar-git 
+  pikaur -S polybar-git ttf-nerd-fonts-symbols
 elif [ -x "$(command -v pakku)" ]; then
-  pakku -S polybar-git 
+  pakku -S polybar-git ttf-nerd-fonts-symbols
 elif [ -x "$(command -v aura)" ]; then
-  aura -SA polybar-git 
+  aura -SA polybar-git ttf-nerd-fonts-symbols
 elif [ -x "$(command -v pacaur)" ]; then
-  pacaur -S polybar-git 
-elif [ -x "$(command -v auracle)" ]; then
-  auracle download polybar-git
-  (cd $PWD/polybar-git && makepkg -si --noconfirm)
+  pacaur -S polybar-git ttf-nerd-fonts-symbols
 else
   echo "No common AUR Helpers found!"
-  echo "This script requires an AUR Helper to install the following packages: polybar-git"
+  echo "This script requires an AUR Helper to install the following packages: polybar-git ttf-nerd-fonts-symbols"
   echo "Please install an AUR helper and try again"
   exit 1
 fi

--- a/install_arch.sh
+++ b/install_arch.sh
@@ -27,10 +27,10 @@ elif [ -x "$(command -v pacaur)" ]; then
   pacaur -S polybar 
 elif [ -x "$(command -v auracle)" ]; then
   auracle download polybar
-  (cd polybar && makepkg -si --noconfirm && cd ../.. && rm -rf polybar)
+  (cd polybar && makepkg -si --noconfirm && cd .. && rm -rf polybar)
 else
   git clone https://aur.archlinux.org/polybar.git 
-  (cd polybar && makepkg -si --noconfirm && cd ../.. && rm -rf polybar)
+  (cd polybar && makepkg -si --noconfirm && cd .. && rm -rf polybar)
   exit 1
 fi
 

--- a/install_arch.sh
+++ b/install_arch.sh
@@ -10,24 +10,27 @@ sudo pacman -Syy
 
 # Added binutils,gcc,make,pkg-config,fakeroot for compilations, removed yaourt
 # Added python-yaml, removed pip install
-sudo pacman -S git nitrogen rofi python-pip ttf-font-awesome adobe-source-code-pro-fonts binutils gcc make pkg-config fakeroot python-yaml --noconfirm
+sudo pacman -S git nitrogen rofi python-pip ttf-font-awesome adobe-source-code-pro-fonts binutils gcc make pkg-config fakeroot python-yaml ttf-nerd-fonts-symbols --noconfirm
 
 # Look for and use common AUR helpers from https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers
 if [ -x "$(command -v yay)" ]; then
-  yay -S polybar-git ttf-nerd-fonts-symbols
+  yay -S polybar-git 
 elif [ -x "$(command -v trizen)" ]; then
-  trizen -S polybar-git ttf-nerd-fonts-symbols
+  trizen -S polybar-git 
 elif [ -x "$(command -v pikaur)" ]; then
-  pikaur -S polybar-git ttf-nerd-fonts-symbols
+  pikaur -S polybar-git 
 elif [ -x "$(command -v pakku)" ]; then
-  pakku -S polybar-git ttf-nerd-fonts-symbols
+  pakku -S polybar-git 
 elif [ -x "$(command -v aura)" ]; then
-  aura -SA polybar-git ttf-nerd-fonts-symbols
+  aura -SA polybar-git 
 elif [ -x "$(command -v pacaur)" ]; then
-  pacaur -S polybar-git ttf-nerd-fonts-symbols
+  pacaur -S polybar-git 
+elif [ -x "$(command -v auracle)" ]; then
+  auracle download polybar-git
+  (cd $PWD/polybar-git && makepkg -si --noconfirm)
 else
   echo "No common AUR Helpers found!"
-  echo "This script requires an AUR Helper to install the following packages: polybar-git ttf-nerd-fonts-symbols"
+  echo "This script requires an AUR Helper to install the following packages: polybar-git"
   echo "Please install an AUR helper and try again"
   exit 1
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.org/simple/
-pyyaml==5.1
+pyyaml==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.org/simple/
-pyyaml==5.3.1
+pyyaml==5.1


### PR DESCRIPTION
install_arch.sh changes:

added auracle as an AUR helper
moved ttf-nerd-fonts-symbols to the pacman -S command as it is now in the arch repository https://www.archlinux.org/packages/community/x86_64/ttf-nerd-fonts-symbols/
 

i3wmthemer/models/configuration.py changes:

added Loader=yaml.FullLoader to line 86 in configuration.py to get the error to go away:` i3wm-themer/i3wmthemer/models/configuration.py:88: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.`